### PR TITLE
Fix 'TypeError: this.server.off is not a function' on shutdown

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -82,8 +82,8 @@ class ServePlugin extends BasePlugin {
 	destroyServer (next) {
 		if (this.server) {
 			this.docpad.log('info', 'Shutting down the server...')
-			this.server.off('error', this.serverError)
-			this.server.off('clientError', this.serverClientError)
+			this.server.removeListener('error', this.serverError)
+			this.server.removeListener('clientError', this.serverClientError)
 			this.server.close((...args) => {
 				this.docpad.log('info', '...shutdown down the server')
 				next(...args)


### PR DESCRIPTION
Using Ctrl+C to stop the server causes the following error:

```js
↳ TypeError: this.server.off is not a function
    at ServePlugin.destroyServer (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/docpad-plugin-serve/source/index.js:85:16)
    at ServePlugin.docpadDestroy (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/docpad-plugin-serve/source/index.js:101:8)
    at ambi (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/ambi/source/index.js:74:3)
    at Domain.fireMethod (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/taskgroup/source/lib/task.js:522:5)
    at Domain.run (domain.js:242:14)
    at Task.fire (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/taskgroup/source/lib/task.js:540:15)
    at Immediate.queue [as _onImmediate] (/home/sergius/Documents/Dev/stellaritysoftware.com-docpad/node_modules/taskgroup/source/lib/task.js:575:20)
    at runCallback (timers.js:794:20)
    at tryOnImmediate (timers.js:752:5)
    at processImmediate [as _immediateCallback] (timers.js:729:5)
```

Apparently `off` method is not supported, I replaced it with `removeListener`.